### PR TITLE
poll.py -> check if timer is registered before attempting to deregister

### DIFF
--- a/poll.py
+++ b/poll.py
@@ -45,7 +45,8 @@ def watch_for_text_changes(
     bpy.app.timers.register(timer)
 
     def dispose():
-        bpy.app.timers.unregister(timer)
+        if bpy.app.timers.is_registered(timer):
+            bpy.app.timers.unregister(timer)
 
     return dispose
 


### PR DESCRIPTION
Currently I am getting some errors when using blendquery because occasionally the timer is not registered before `dispose()` tries to deregister. This PR adds a check that it is registered before attempting.