### PR TITLE
fix: `.communicate` crashes when `parse.py` exits before `communicate()` is called.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -211,7 +211,8 @@ def create_parse_parametric_script_thread(script: str):
         process.stdin.write(pickle.dumps(script))
         process.stdin.close()
 
-        stdout_data = process.stdout.read();
+        process.wait()
+        stdout_data = process.stdout.read()
         response.put(pickle.loads(stdout_data))
 
         # TODO: Investigate return code issue.

--- a/__init__.py
+++ b/__init__.py
@@ -211,7 +211,7 @@ def create_parse_parametric_script_thread(script: str):
         process.stdin.write(pickle.dumps(script))
         process.stdin.close()
 
-        stdout_data, stderr_data = process.communicate()
+        stdout_data = process.stdout.read();
         response.put(pickle.loads(stdout_data))
 
         # TODO: Investigate return code issue.

--- a/__init__.py
+++ b/__init__.py
@@ -139,9 +139,10 @@ class BlendQueryPropertyGroup(bpy.types.PropertyGroup):
 
 
 def ui_update(self, context):
-    for region in context.area.regions:
-        if region.type == "UI":
-            region.tag_redraw()
+    if context.area:
+        for region in context.area.regions:
+            if region.type == "UI":
+                region.tag_redraw()
     return None
 
 
@@ -212,8 +213,9 @@ def create_parse_parametric_script_thread(script: str):
         process.stdin.close()
 
         process.wait()
+        assert process.stdout
         stdout_data = process.stdout.read()
-        response.put(pickle.loads(stdout_data))
+        response.put(pickle.loads(stdout_data if stdout_data else b""))
 
         # TODO: Investigate return code issue.
         # if process.returncode == 0:

--- a/__init__.py
+++ b/__init__.py
@@ -208,13 +208,14 @@ def create_parse_parametric_script_thread(script: str):
         parent_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
         env = os.environ.copy()
         env['PATH'] = parent_directory
-        process = subprocess.Popen([sys.executable, 'parse.py'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, env=env)
+        process = subprocess.Popen([sys.executable, 'parse.py'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=cwd, env=env)
         process.stdin.write(pickle.dumps(script))
         process.stdin.close()
 
-        process.wait()
         assert process.stdout
         stdout_data = process.stdout.read()
+        process.wait()
+
         response.put(pickle.loads(stdout_data if stdout_data else b""))
 
         # TODO: Investigate return code issue.


### PR DESCRIPTION
Fixes https://github.com/uki-dev/blendquery/issues/6